### PR TITLE
feat(ui): adding glass input component

### DIFF
--- a/mindblock/src/App.css
+++ b/mindblock/src/App.css
@@ -12,3 +12,41 @@
   --color-text: #ffff;
   --color-gray: #212122;
 }
+.border-hidden {
+  border-color: transparent !important;
+}
+.glow-border::before {
+  content: "";
+  position: absolute;
+  inset: -1px;
+  border-radius: 0.375rem;
+  background: linear-gradient(
+    270deg,
+    var(--color-primary-glow),
+    var(--color-secondary-glow),
+    var(--color-primary-glow)
+  );
+  background-size: 300% 300%;
+  z-index: 0;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.4s ease-in-out;
+}
+
+.animate-glow::before {
+  opacity: 1;
+  animation: border-shine 1.4s ease-in-out forwards;
+}
+
+.fade-out-glow::before {
+  opacity: 0;
+}
+
+@keyframes border-shine {
+  0% {
+    background-position: 0% 50%;
+  }
+  100% {
+    background-position: 200% 50%;
+  }
+}

--- a/mindblock/src/components/GameFeatures.tsx
+++ b/mindblock/src/components/GameFeatures.tsx
@@ -1,9 +1,13 @@
 import { Brain, Trophy, Code } from "lucide-react";
 import { GameFeatureCard } from "../ui/GameFeatureCard";
+import { GlassInput } from "./atoms/GlassInput/GlassInput";
 
 function GameFeature() {
+  const doSomething = () => {
+    console.log("first");
+  };
 
-  //game feature data 
+  //game feature data
   const features = [
     {
       icon: Brain,
@@ -26,13 +30,12 @@ function GameFeature() {
   ];
 
   return (
-    <div className='min-h-screen bg-gradient-to-br from-gray-900 to-black text-white'>
-      <div className='container mx-auto px-4 py-16'>
-        <h2 className='text-3xl font-bold text-center mb-12 text-transparent bg-clip-text bg-gradient-to-r from-blue-400 to-purple-500'>
+    <div className="min-h-screen bg-gradient-to-br from-gray-900 to-black text-white">
+      <div className="container mx-auto px-4 py-16">
+        <h2 className="text-3xl font-bold text-center mb-12 text-transparent bg-clip-text bg-gradient-to-r from-blue-400 to-purple-500">
           Game Features
         </h2>
-        <div className='grid grid-cols-1 md:grid-cols-3 gap-8'>
-          
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
           {features.map((feature, index) => (
             <GameFeatureCard
               key={index}
@@ -42,6 +45,16 @@ function GameFeature() {
             />
           ))}
         </div>
+      </div>
+      <div className="flex items-center justify-center mt-50">
+        <GlassInput
+          id="Username"
+          label="Username"
+          onChange={doSomething}
+          value=""
+          type="email"
+          placeholder="Choose a username"
+        />
       </div>
     </div>
   );

--- a/mindblock/src/components/atoms/GlassInput/GlassInput.tsx
+++ b/mindblock/src/components/atoms/GlassInput/GlassInput.tsx
@@ -1,0 +1,77 @@
+import { GlassInputProps } from "./types/GlassInput.types";
+import { useGlowAnimation } from "./hooks/useGlowAnimation";
+import { getDefaultIcon } from "./utils/IconUtils";
+
+export const GlassInput = ({
+  id,
+  label,
+  value,
+  onChange,
+  type = "text",
+  placeholder,
+  disabled = false,
+  required = false,
+  className,
+  icon,
+  iconPosition = "left",
+}: GlassInputProps) => {
+  const resolvedIcon = icon ?? getDefaultIcon(type);
+  const hasLeftIcon = resolvedIcon && iconPosition === "left";
+  const hasRightIcon = resolvedIcon && iconPosition === "right";
+
+  const { glowRef, inputRef, triggerGlow } = useGlowAnimation();
+
+  return (
+    <div className={`glow-wrapper relative flex flex-col gap-1 ${className}`}>
+      <label htmlFor={id} className="text-sm text-white/60 font-secondary">
+        {label}
+      </label>
+
+      <div
+        ref={glowRef}
+        className="relative w-full rounded-md glow-border"
+        onFocus={triggerGlow}
+      >
+        {hasLeftIcon && (
+          <span className="absolute left-3 top-1/2 -translate-y-1/2 z-20">
+            {resolvedIcon}
+          </span>
+        )}
+
+        <input
+          ref={inputRef}
+          id={id}
+          type={type}
+          value={value}
+          onChange={onChange}
+          placeholder={placeholder}
+          disabled={disabled}
+          required={required}
+          aria-label={label}
+          className={`
+            relative z-10
+            w-full
+            px-4 py-2.5
+            ${hasLeftIcon ? "pl-10" : ""}
+            ${hasRightIcon ? "pr-10" : ""}
+            rounded-md
+            text-white
+            bg-secondary-dark
+            placeholder-white/50
+            border border-white/10
+            focus:outline-none
+            text-sm
+            font-secondary
+            transition-all duration-300
+          `}
+        />
+
+        {hasRightIcon && (
+          <span className="absolute right-3 top-1/2 -translate-y-1/2 z-20">
+            {resolvedIcon}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/mindblock/src/components/atoms/GlassInput/hooks/useGlowAnimation.ts
+++ b/mindblock/src/components/atoms/GlassInput/hooks/useGlowAnimation.ts
@@ -1,0 +1,32 @@
+import { useRef } from "react";
+
+export const useGlowAnimation = () => {
+  const glowRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const triggerGlow = () => {
+    const wrapper = glowRef.current;
+    const input = inputRef.current;
+
+    if (wrapper && input) {
+      wrapper.classList.add("animate-glow");
+      input.classList.add("border-hidden");
+
+      setTimeout(() => {
+        wrapper.classList.remove("animate-glow");
+        wrapper.classList.add("fade-out-glow");
+      }, 1000);
+
+      setTimeout(() => {
+        wrapper.classList.remove("fade-out-glow");
+        input.classList.remove("border-hidden");
+      }, 0);
+    }
+  };
+
+  return {
+    glowRef,
+    inputRef,
+    triggerGlow,
+  };
+};

--- a/mindblock/src/components/atoms/GlassInput/types/GlassInput.types.ts
+++ b/mindblock/src/components/atoms/GlassInput/types/GlassInput.types.ts
@@ -1,0 +1,13 @@
+export interface GlassInputProps {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  type?: string;
+  placeholder?: string;
+  disabled?: boolean;
+  required?: boolean;
+  className?: string;
+  icon?: React.ReactNode;
+  iconPosition?: "left" | "right";
+}

--- a/mindblock/src/components/atoms/GlassInput/utils/IconUtils.tsx
+++ b/mindblock/src/components/atoms/GlassInput/utils/IconUtils.tsx
@@ -1,0 +1,13 @@
+import { MailIcon, LockIcon } from "lucide-react";
+import { JSX } from "react";
+
+export const getDefaultIcon = (type: string): JSX.Element | null => {
+  switch (type) {
+    case "email":
+      return <MailIcon className="w-4 h-4 text-white/50" />;
+    case "password":
+      return <LockIcon className="w-4 h-4 text-white/50" />;
+    default:
+      return null;
+  }
+};


### PR DESCRIPTION
resolves: #5 
## GlassInput Component – Cyberpunk Neon Input Field

This PR introduces the `GlassInput` component, a reusable input field designed to match the futuristic visual style of Mind Block. It combines a glassmorphic aesthetic with a neon glow border animation to enhance user experience and visual consistency.

### Key Features

- Translucent background with `backdrop-blur`
- Soft purple border (`primary-glow`) in idle state
- Border animation wth a purple-to-cyan gradient on focus
- The glow lasts 1.4s and fades out smoothly, returning to the base style
- Supports automatic icons based on `type` (`email`, `password`) or custom icons
- Accessible: includes `aria-label`, keyboard navigation, and clear focus styles

### Technical Implementation

- Animation logic encapsulated in a custom hook: `useGlowAnimation`
- Default icons separated into a utility function: `getDefaultIcon`
- Structured according to Atomic Design (`atoms/GlassInput`)

### Purpose

This input enhances the visual experience of form elements in Mind Block, following the cyberpunk design specified in the Figma guide. It promotes consistent design in screens like login, registration, and settings.

