### PR TITLE
created starknet to sign up and sigin page

### DIFF
--- a/mindblock/src/components/authUtils.ts
+++ b/mindblock/src/components/authUtils.ts
@@ -4,8 +4,9 @@ export type User = {
   username?: string;
   email: string;
   password?: string;
-  provider?: "local" | "google";
+  provider?: "local" | "google" | "starknet";
   googleId?: string;
+  starknetAddress?: string;
 };
 
 const USERS_KEY = "mindblock_users";
@@ -71,6 +72,25 @@ export function mockGoogleAuth(): {
   saveUsers(users);
   setAuthUser(googleUser);
   return { success: true, user: googleUser };
+}
+
+// Mock StarkNet registration utility (for possible future use)
+export function mockStarknetRegister(): { success: boolean; user?: User; error?: string } {
+  const starknetAddress = "0x" + Math.floor(Math.random() * 1e16).toString(16);
+  const starknetUser: User = {
+    username: `starknet_${starknetAddress.slice(-6)}`,
+    email: `${starknetAddress}@starknet.io`,
+    provider: "starknet",
+    starknetAddress,
+  };
+  const users = getUsers();
+  if (users.some((u) => u.starknetAddress === starknetAddress)) {
+    return { success: false, error: "StarkNet wallet already registered" };
+  }
+  users.push(starknetUser);
+  saveUsers(users);
+  setAuthUser(starknetUser);
+  return { success: true, user: starknetUser };
 }
 
 export function setAuthUser(user: User) {

--- a/mindblock/src/pages/Signup.tsx
+++ b/mindblock/src/pages/Signup.tsx
@@ -81,6 +81,39 @@ const SignupForm = () => {
     }
   };
 
+  // Mock StarkNet registration handler
+  const handleStarknetSignup = async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      // Simulate StarkNet wallet address
+      const starknetAddress = "0x" + Math.floor(Math.random() * 1e16).toString(16);
+      const starknetUser = {
+        username: `starknet_${starknetAddress.slice(-6)}`,
+        email: `${starknetAddress}@starknet.io`,
+        password: undefined,
+        provider: "starknet",
+        starknetAddress,
+      };
+      // Store in localStorage (merge with existing users)
+      const users = JSON.parse(localStorage.getItem("mindblock_users") || "[]");
+      if (users.some((u: any) => u.starknetAddress === starknetAddress)) {
+        setError("StarkNet wallet already registered");
+        setIsLoading(false);
+        return;
+      }
+      users.push(starknetUser);
+      localStorage.setItem("mindblock_users", JSON.stringify(users));
+      localStorage.setItem("mindblock_auth", JSON.stringify(starknetUser));
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      navigate("/");
+    } catch (error) {
+      setError("StarkNet signup error");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-900">
       <div className="max-w-md w-full space-y-8 p-8 bg-gray-800 rounded-lg shadow-lg">
@@ -200,6 +233,7 @@ const SignupForm = () => {
               </button>
               <button
                 type="button"
+                onClick={handleStarknetSignup}
                 className="flex items-center justify-center py-2 px-4 border border-gray-700 rounded-md hover:border-cyan-400/30 hover:shadow-sm hover:shadow-cyan-400/20 bg-gray-800/50 text-white transition duration-200"
               >
                 StarkNet


### PR DESCRIPTION

 implemented a complete authentication system for the Mind Block application. Currently, we have UI components for login and signup with form validations, but we need to implement the starknet authentication logic.

Detailed Requirements:
Complete the registration form functionality in src/components/signup.tsx and src/components/login.tsx, Store user data in localStorage (for now, until backend integration)

Implement a mock Starknet authentication flow for registeration/login
Store Starknet user data in localStorage
Handle auth errors properly
Redirect to home page after successful registration/login

Expected Outcome:
Users can register for a new account
Users can log in with starknet

Acceptance Criteria:
User registration stores data correctly in localStorage
User login authenticates against stored data
Authentication state persists after page refresh
PROVIDE A CLEAR DESCRIPTION WHAT HAS IMPLEMENTED
KINDLY TEST BEFORE CREATING A PR.

Activity

